### PR TITLE
Bring over fix multiscene ASV crash from main

### DIFF
--- a/Gem/Code/Source/MultiSceneExampleComponent.cpp
+++ b/Gem/Code/Source/MultiSceneExampleComponent.cpp
@@ -71,6 +71,8 @@ namespace AtomSampleViewer
 
         // Create the RPI::Scene, add some feature processors
         RPI::SceneDescriptor sceneDesc;
+        sceneDesc.m_featureProcessorNames.push_back("AZ::Render::SimplePointLightFeatureProcessor");
+        sceneDesc.m_featureProcessorNames.push_back("AZ::Render::SimpleSpotLightFeatureProcessor");
         sceneDesc.m_featureProcessorNames.push_back("AZ::Render::CapsuleLightFeatureProcessor");
         sceneDesc.m_featureProcessorNames.push_back("AZ::Render::DecalTextureArrayFeatureProcessor");
         sceneDesc.m_featureProcessorNames.push_back("AZ::Render::DirectionalLightFeatureProcessor");


### PR DESCRIPTION
The light culling system is expecting SimplePointLightFeatureProcessor and SimpleSpotLightFeatureProcessor to be available otherwise it will crash

Tested ASV multiscene with Vulkan. It crashes without this changes and works with this change

NOJIRA