### PR TITLE
Add support for a XR sample using Oculus link

### DIFF
--- a/Gem/Code/Source/Platform/Windows/additional_windows_runtime_library.cmake
+++ b/Gem/Code/Source/Platform/Windows/additional_windows_runtime_library.cmake
@@ -5,3 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #
+
+set(LY_RUNTIME_DEPENDENCIES
+    Gem::XR
+    Gem::OpenXRVk
+)

--- a/Gem/Code/Source/RHI/BasicRHIComponent.cpp
+++ b/Gem/Code/Source/RHI/BasicRHIComponent.cpp
@@ -57,7 +57,7 @@ namespace AtomSampleViewer
         // The RHISamplePass template should have one owned image attachment which is the render target
         m_outputAttachment = m_ownedAttachments[0];
 
-        // Force udpate pass attachment to get currect size and save it to local variables
+        // Force update pass attachment to get correct size and save it to local variables
         m_outputAttachment->Update();
 
         // update output info for the rhi sample
@@ -88,6 +88,16 @@ namespace AtomSampleViewer
                 frameGraphBuilder->ImportScopeProducer(*producer);
             }
         }
+    }
+
+    uint32_t RHISamplePass::GetViewIndex() const
+    {
+        return m_viewIndex;
+    }
+
+    void RHISamplePass::SetViewIndex(const uint32_t viewIndex)
+    {
+        m_viewIndex = viewIndex;
     }
 
     bool BasicRHIComponent::ReadInConfig(const AZ::ComponentConfig* baseConfig)
@@ -609,5 +619,10 @@ namespace AtomSampleViewer
     float BasicRHIComponent::GetViewportHeight()
     {
         return m_viewport.m_maxY - m_viewport.m_minY;
+    }
+
+    void BasicRHIComponent::SetViewIndex(const uint32_t viewIndex)
+    {
+        m_viewIndex = viewIndex;
     }
 }

--- a/Gem/Code/Source/RHI/BasicRHIComponent.h
+++ b/Gem/Code/Source/RHI/BasicRHIComponent.h
@@ -66,6 +66,10 @@ namespace AtomSampleViewer
         // Pass overrides
         const AZ::RPI::PipelineViewTag& GetPipelineViewTag() const override;
 
+        // Return the view index of the pass
+        uint32_t GetViewIndex() const;
+        void SetViewIndex(const uint32_t viewIndex);
+
     protected:
         explicit RHISamplePass(const AZ::RPI::PassDescriptor& descriptor);
 
@@ -78,6 +82,9 @@ namespace AtomSampleViewer
         AZ::RPI::Ptr<AZ::RPI::PassAttachment> m_outputAttachment;
 
         AZ::RPI::PipelineViewTag m_pipelineViewTag;
+
+        // Used to determine view index for XR sample
+        uint32_t m_viewIndex = 0;
     };
 
     class BasicRHIComponent
@@ -103,6 +110,8 @@ namespace AtomSampleViewer
         
         float GetViewportHeight();
         
+        void SetViewIndex(const uint32_t viewIndex);
+       
     protected:
         AZ_DISABLE_COPY(BasicRHIComponent);
 
@@ -237,5 +246,8 @@ namespace AtomSampleViewer
 
         // whether this sample supports RHI sample render pipeline or not
         bool m_supportRHISamplePipeline = false;
+        
+        // view index. Used by XR related samples
+        uint32_t m_viewIndex = 0;
     };
 } // namespace AtomSampleViewer

--- a/Gem/Code/Source/RHI/XRExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/XRExampleComponent.cpp
@@ -1,0 +1,377 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <RHI/XRExampleComponent.h>
+#include <Utils/Utils.h>
+
+#include <SampleComponentManager.h>
+
+#include <Atom/RHI/CommandList.h>
+#include <Atom/RHI.Reflect/InputStreamLayoutBuilder.h>
+#include <Atom/RHI.Reflect/RenderAttachmentLayoutBuilder.h>
+#include <Atom/RPI.Public/Shader/Shader.h>
+#include <Atom/RPI.Reflect/Shader/ShaderAsset.h>
+#include <AzCore/Serialization/SerializeContext.h>
+
+namespace AtomSampleViewer
+{
+    //Colors for different faces of the cube
+    const AZ::Vector4 Red = AZ::Vector4(1, 0, 0, 0);
+    const AZ::Vector4 DarkRed = AZ::Vector4(0.25f, 0, 0, 0);
+    const AZ::Vector4 Green = AZ::Vector4(0, 1, 0, 0);
+    const AZ::Vector4 DarkGreen = AZ::Vector4(0, 0.25f, 0, 0);
+    const AZ::Vector4 Blue = AZ::Vector4(0, 0, 1, 0);
+    const AZ::Vector4 DarkBlue = AZ::Vector4(0, 0, 0.25f, 0);
+
+    void XRExampleComponent::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<XRExampleComponent, AZ::Component>()->Version(0);
+        }
+    }
+
+    XRExampleComponent::XRExampleComponent()
+    {
+        m_supportRHISamplePipeline = true;
+    }
+
+    void XRExampleComponent::Activate()
+    {
+        using namespace AZ;
+
+        CreateCubeInputAssemblyBuffer();
+        CreateCubePipeline();
+        CreateScope();
+        AZ::RHI::RHISystemNotificationBus::Handler::BusConnect();
+        AZ::TickBus::Handler::BusConnect();
+    }
+
+    void XRExampleComponent::OnTick(float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)
+    {
+        m_time += deltaTime;
+    }
+
+    void XRExampleComponent::OnFramePrepare(AZ::RHI::FrameGraphBuilder& frameGraphBuilder)
+    {
+        AZ::Matrix4x4 projection = AZ::Matrix4x4::CreateIdentity();
+        AZ::Matrix4x4 vpMat = AZ::Matrix4x4::CreateIdentity();
+
+        AZ::RPI::XRRenderingInterface* xrSystem = AZ::RPI::RPISystemInterface::Get()->GetXRSystem();
+        if (xrSystem && xrSystem->ShouldRender())
+        {
+            AZ::RPI::FovData fovData = xrSystem->GetViewFov(m_viewIndex);
+            AZ::RPI::PoseData poseData = xrSystem->GetViewPose(m_viewIndex);
+                
+            static const float clip_near = 0.05f;
+            static const float clip_far = 100.0f;
+            projection = xrSystem->CreateProjectionOffset(fovData.m_angleLeft, fovData.m_angleRight, 
+                                                          fovData.m_angleDown, fovData.m_angleUp, 
+                                                          clip_near, clip_far);
+
+            AZ::Matrix4x4 viewMat = AZ::Matrix4x4::CreateFromQuaternionAndTranslation(poseData.orientation, poseData.position);;
+            viewMat.InvertTransform();
+            m_viewProjMatrix = projection * viewMat;
+ 
+            AZ::Matrix4x4 initialScaleMat = AZ::Matrix4x4::CreateScale(AZ::Vector3(0.1f, 0.1f, 0.1f));
+
+            //Model matrix for the cube related to the front view
+            AZ::RPI::PoseData frontViewPoseData = xrSystem->GetViewFrontPose();
+            m_modelMatrices[0] = AZ::Matrix4x4::CreateFromQuaternionAndTranslation(frontViewPoseData.orientation, frontViewPoseData.position) * initialScaleMat;
+                      
+            //Model matrix for the cube related to the left controller
+            AZ::RPI::PoseData controllerLeftPose = xrSystem->GetControllerPose(0);
+            AZ::Matrix4x4 leftScaleMat = initialScaleMat * AZ::Matrix4x4::CreateScale(AZ::Vector3(xrSystem->GetControllerScale(0), xrSystem->GetControllerScale(0), xrSystem->GetControllerScale(0)));
+            m_modelMatrices[1] = AZ::Matrix4x4::CreateFromQuaternionAndTranslation(controllerLeftPose.orientation, controllerLeftPose.position) * leftScaleMat;
+
+            //Model matrix for the cube related to the right controller
+            AZ::Matrix4x4 rightScaleMat = initialScaleMat * AZ::Matrix4x4::CreateScale(AZ::Vector3(xrSystem->GetControllerScale(1), xrSystem->GetControllerScale(1), xrSystem->GetControllerScale(1)));
+            AZ::RPI::PoseData controllerRightPose = xrSystem->GetControllerPose(1);
+            m_modelMatrices[2] = AZ::Matrix4x4::CreateFromQuaternionAndTranslation(controllerRightPose.orientation, controllerRightPose.position) * rightScaleMat;
+        }      
+        
+        for (int i = 0; i < s_numberOfCubes; ++i)
+        {
+            m_shaderResourceGroups[i]->SetConstant(m_shaderIndexWorldMat, m_modelMatrices[i]);
+            m_shaderResourceGroups[i]->SetConstant(m_shaderIndexViewProj, m_viewProjMatrix);
+            m_shaderResourceGroups[i]->Compile();
+        }
+
+        BasicRHIComponent::OnFramePrepare(frameGraphBuilder);
+    }
+
+    XRExampleComponent::SingleCubeBufferData XRExampleComponent::CreateSingleCubeBufferData([[maybe_unused]] const AZ::Vector4 color)
+    {
+        AZStd::vector<AZ::Vector4> vertexColor =
+        {
+            //Front Face
+            DarkBlue, DarkBlue, DarkBlue, DarkBlue,
+            //Back Face                                                                       
+            Blue, Blue, Blue, Blue,
+            //Left Face                                                                      
+            DarkGreen, DarkGreen, DarkGreen, DarkGreen,
+            //Right Face                                                                    
+            Green, Green, Green, Green,
+            //Top Face                                                                  
+            DarkRed, DarkRed, DarkRed, DarkRed,
+            //Bottom Face                                                                    
+            Red, Red, Red, Red,
+        };
+
+        // Create vertices, colors and normals for a cube and a plane
+        SingleCubeBufferData bufferData;
+        {
+            
+            AZStd::vector<AZ::Vector3> vertices =
+            {
+                //Front Face
+                AZ::Vector3(1.0, 1.0, 1.0),         AZ::Vector3(-1.0, 1.0, 1.0),     AZ::Vector3(-1.0, -1.0, 1.0),    AZ::Vector3(1.0, -1.0, 1.0),
+                //Back Face                                                                       
+                AZ::Vector3(1.0, 1.0, -1.0),        AZ::Vector3(-1.0, 1.0, -1.0),    AZ::Vector3(-1.0, -1.0, -1.0),   AZ::Vector3(1.0, -1.0, -1.0),
+                //Left Face                                                                      
+                AZ::Vector3(-1.0, 1.0, 1.0),        AZ::Vector3(-1.0, -1.0, 1.0),    AZ::Vector3(-1.0, -1.0, -1.0),   AZ::Vector3(-1.0, 1.0, -1.0),
+                //Right Face                                                                    
+                AZ::Vector3(1.0, 1.0, 1.0),         AZ::Vector3(1.0, -1.0, 1.0),     AZ::Vector3(1.0, -1.0, -1.0),    AZ::Vector3(1.0, 1.0, -1.0),
+                //Top Face                                                                  
+                AZ::Vector3(1.0, 1.0, 1.0),         AZ::Vector3(-1.0, 1.0, 1.0),     AZ::Vector3(-1.0, 1.0, -1.0),    AZ::Vector3(1.0, 1.0, -1.0),
+                //Bottom Face                                                                    
+                AZ::Vector3(1.0, -1.0, 1.0),        AZ::Vector3(-1.0, -1.0, 1.0),    AZ::Vector3(-1.0, -1.0, -1.0),   AZ::Vector3(1.0, -1.0, -1.0),
+            };
+
+            for (int i = 0; i < s_geometryVertexCount; ++i)
+            {
+                SetVertexPosition(bufferData.m_positions.data(), i, vertices[i]);
+                SetVertexColor(bufferData.m_colors.data(), i, vertexColor[i]);
+            }
+
+            bufferData.m_indices =
+            {
+                {
+                    //Back
+                    2, 0, 1,
+                    0, 2, 3,
+                    //Front
+                    4, 6, 5,
+                    6, 4, 7,
+                    //Left
+                    8, 10, 9,
+                    10, 8, 11,
+                    //Right
+                    14, 12, 13,
+                    15, 12, 14,
+                    //Top
+                    16, 18, 17,
+                    18, 16, 19,
+                    //Bottom
+                    22, 20, 21,
+                    23, 20, 22,
+                }
+            };
+        }
+        return bufferData;
+    }
+
+    void XRExampleComponent::CreateCubeInputAssemblyBuffer()
+    {
+        const AZ::RHI::Ptr<AZ::RHI::Device> device = Utils::GetRHIDevice();
+        AZ::RHI::ResultCode result = AZ::RHI::ResultCode::Success;
+
+        m_bufferPool = AZ::RHI::Factory::Get().CreateBufferPool();
+        AZ::RHI::BufferPoolDescriptor bufferPoolDesc;
+        bufferPoolDesc.m_bindFlags = AZ::RHI::BufferBindFlags::InputAssembly;
+        bufferPoolDesc.m_heapMemoryLevel = AZ::RHI::HeapMemoryLevel::Device;
+        result = m_bufferPool->Init(*device, bufferPoolDesc);
+        if (result != AZ::RHI::ResultCode::Success)
+        {
+            AZ_Error("XRExampleComponent", false, "Failed to initialize buffer pool with error code %d", result);
+            return;
+        }
+
+        SingleCubeBufferData bufferData = CreateSingleCubeBufferData(AZ::Vector4(1.0f, 0.0f, 0.0f, 0.0f));
+
+        m_inputAssemblyBuffer = AZ::RHI::Factory::Get().CreateBuffer();
+        AZ::RHI::BufferInitRequest request;
+
+        request.m_buffer = m_inputAssemblyBuffer.get();
+        request.m_descriptor = AZ::RHI::BufferDescriptor{ AZ::RHI::BufferBindFlags::InputAssembly, sizeof(SingleCubeBufferData) };
+        request.m_initialData = &bufferData;
+        result = m_bufferPool->InitBuffer(request);
+        if (result != AZ::RHI::ResultCode::Success)
+        {
+            AZ_Error("XRExampleComponent", false, "Failed to initialize buffer with error code %d", result);
+            return;
+        }
+
+        m_streamBufferViews[0] =
+        {
+            *m_inputAssemblyBuffer,
+            offsetof(SingleCubeBufferData, m_positions),
+            sizeof(SingleCubeBufferData::m_positions),
+            sizeof(VertexPosition)
+        };
+
+        m_streamBufferViews[1] =
+        {
+            *m_inputAssemblyBuffer,
+            offsetof(SingleCubeBufferData, m_colors),
+            sizeof(SingleCubeBufferData::m_colors),
+            sizeof(VertexColor)
+        };
+
+        m_indexBufferView =
+        {
+            *m_inputAssemblyBuffer,
+            offsetof(SingleCubeBufferData, m_indices),
+            sizeof(SingleCubeBufferData::m_indices),
+            AZ::RHI::IndexFormat::Uint16
+        };
+
+        AZ::RHI::InputStreamLayoutBuilder layoutBuilder;
+        layoutBuilder.SetTopology(AZ::RHI::PrimitiveTopology::TriangleList);
+        layoutBuilder.AddBuffer()->Channel("POSITION", AZ::RHI::Format::R32G32B32_FLOAT);
+        layoutBuilder.AddBuffer()->Channel("COLOR", AZ::RHI::Format::R32G32B32A32_FLOAT);
+        m_streamLayoutDescriptor.Clear();
+        m_streamLayoutDescriptor = layoutBuilder.End();
+
+        AZ::RHI::ValidateStreamBufferViews(m_streamLayoutDescriptor, m_streamBufferViews);
+    }
+
+    void XRExampleComponent::CreateCubePipeline()
+    {
+        const char* shaderFilePath = "Shaders/RHI/OpenXrSample.azshader";
+        const char* sampleName = "XRExampleComponent";
+
+        auto shader = LoadShader(shaderFilePath, sampleName);
+        if (shader == nullptr)
+        { 
+            return;
+        }
+
+        const AZ::RHI::Ptr<AZ::RHI::Device> device = Utils::GetRHIDevice();
+        AZ::RHI::PipelineStateDescriptorForDraw pipelineDesc;
+        shader->GetVariant(AZ::RPI::ShaderAsset::RootShaderVariantStableId).ConfigurePipelineState(pipelineDesc);
+        pipelineDesc.m_inputStreamLayout = m_streamLayoutDescriptor;
+        
+        AZ::RHI::RenderAttachmentLayoutBuilder attachmentsBuilder;
+        attachmentsBuilder.AddSubpass()
+            ->RenderTargetAttachment(m_outputFormat);
+            
+        [[maybe_unused]] AZ::RHI::ResultCode result = attachmentsBuilder.End(pipelineDesc.m_renderAttachmentConfiguration.m_renderAttachmentLayout);
+        AZ_Assert(result == AZ::RHI::ResultCode::Success, "Failed to create render attachment layout");
+
+        m_pipelineState = shader->AcquirePipelineState(pipelineDesc);
+        if (!m_pipelineState)
+        {
+            AZ_Error("XRExampleComponent", false, "Failed to acquire default pipeline state for shader '%s'", shaderFilePath);
+            return;
+        }
+
+        auto perInstanceSrgLayout = shader->FindShaderResourceGroupLayout(AZ::Name{ "OpenXrSrg" });
+        if (!perInstanceSrgLayout)
+        {
+            AZ_Error("XRExampleComponent", false, "Failed to get shader resource group layout");
+            return;
+        }
+
+        for (int i = 0; i < s_numberOfCubes; ++i)
+        {
+            m_shaderResourceGroups[i] = CreateShaderResourceGroup(shader, "OpenXrSrg", sampleName);
+
+            FindShaderInputIndex(&m_shaderIndexWorldMat, m_shaderResourceGroups[i], AZ::Name{ "m_worldMatrix" }, "XRExampleComponent");
+            FindShaderInputIndex(&m_shaderIndexViewProj, m_shaderResourceGroups[i], AZ::Name{ "m_viewProjMatrix" }, "XRExampleComponent");
+        }
+    }
+
+    void XRExampleComponent::CreateScope()
+    {
+        // Creates a scope for rendering the triangle.
+        struct ScopeData
+        {
+
+        };
+        const auto prepareFunction = [this](AZ::RHI::FrameGraphInterface frameGraph, [[maybe_unused]] ScopeData& scopeData)
+        {
+            // Binds the swap chain as a color attachment. Clears it to black.
+            {
+                AZ::RHI::ImageScopeAttachmentDescriptor descriptor;
+                descriptor.m_attachmentId = m_outputAttachmentId;
+                descriptor.m_loadStoreAction.m_loadAction = AZ::RHI::AttachmentLoadAction::Load;
+                frameGraph.UseColorAttachment(descriptor);
+            }
+
+            // We will submit s_numberOfCubes draw items.
+            frameGraph.SetEstimatedItemCount(s_numberOfCubes);
+        };
+
+        AZ::RHI::EmptyCompileFunction<ScopeData> compileFunction;
+
+        const auto executeFunction = [this](const AZ::RHI::FrameGraphExecuteContext& context, [[maybe_unused]] const ScopeData& scopeData)
+        {
+            AZ::RHI::CommandList* commandList = context.GetCommandList();
+
+            // Set persistent viewport and scissor state.
+            commandList->SetViewports(&m_viewport, 1);
+            commandList->SetScissors(&m_scissor, 1);
+
+            AZ::RHI::DrawIndexed drawIndexed;
+            drawIndexed.m_indexCount = s_geometryIndexCount;
+            drawIndexed.m_instanceCount = 1;
+
+            // Dividing s_numberOfCubes by context.GetCommandListCount() to balance to number 
+            // of draw call equally between each thread.
+            uint32_t numberOfCubesPerCommandList = s_numberOfCubes / context.GetCommandListCount();
+            uint32_t indexStart = context.GetCommandListIndex() * numberOfCubesPerCommandList;
+            uint32_t indexEnd = indexStart + numberOfCubesPerCommandList;
+
+            if (context.GetCommandListIndex() == context.GetCommandListCount() - 1)
+            {
+                indexEnd = s_numberOfCubes;
+            }
+
+            for (uint32_t i = indexStart; i < indexEnd; ++i)
+            {
+                const AZ::RHI::ShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroups[i]->GetRHIShaderResourceGroup() };
+
+                AZ::RHI::DrawItem drawItem;
+                drawItem.m_arguments = drawIndexed;
+                drawItem.m_pipelineState = m_pipelineState.get();
+                drawItem.m_indexBufferView = &m_indexBufferView;
+                drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(AZ::RHI::ArraySize(shaderResourceGroups));
+                drawItem.m_shaderResourceGroups = shaderResourceGroups;
+                drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
+                drawItem.m_streamBufferViews = m_streamBufferViews.data();
+
+                commandList->Submit(drawItem);
+            }
+        };
+
+        m_scopeProducers.emplace_back(
+            aznew AZ::RHI::ScopeProducerFunction<
+            ScopeData,
+            decltype(prepareFunction),
+            decltype(compileFunction),
+            decltype(executeFunction)>(
+                AZ::RHI::ScopeId{ AZStd::string::format("XRSample_Id_ % u", GetId()) },
+                ScopeData{},
+                prepareFunction,
+                compileFunction,
+                executeFunction));
+    }
+
+    void XRExampleComponent::Deactivate()
+    {
+        m_inputAssemblyBuffer = nullptr;
+        m_bufferPool = nullptr;
+        m_pipelineState = nullptr;
+        m_shaderResourceGroups.fill(nullptr);
+
+        AZ::RHI::RHISystemNotificationBus::Handler::BusDisconnect();
+        m_windowContext = nullptr;
+        m_scopeProducers.clear();
+    }
+} 

--- a/Gem/Code/Source/RHI/XRExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/XRExampleComponent.cpp
@@ -35,7 +35,7 @@ namespace AtomSampleViewer
 
     void XRExampleComponent::Activate()
     {
-        m_depthStencilID = AZ::RHI::AttachmentId{ AZStd::string::format("DepthStencilID_ % u", GetId()) };
+        m_depthStencilID = AZ::RHI::AttachmentId{ AZStd::string::format("DepthStencilID_% u", GetId()) };
         CreateCubeInputAssemblyBuffer();
         CreateCubePipeline();
         CreateScope();
@@ -373,7 +373,7 @@ namespace AtomSampleViewer
             decltype(prepareFunction),
             decltype(compileFunction),
             decltype(executeFunction)>(
-                AZ::RHI::ScopeId{ AZStd::string::format("XRSample_Id_ % u", GetId()) },
+                AZ::RHI::ScopeId{ AZStd::string::format("XRSample_Id_% u", GetId()) },
                 ScopeData{},
                 prepareFunction,
                 compileFunction,

--- a/Gem/Code/Source/RHI/XRExampleComponent.h
+++ b/Gem/Code/Source/RHI/XRExampleComponent.h
@@ -34,7 +34,7 @@ namespace AtomSampleViewer
         , public AZ::TickBus::Handler
     {
     public:
-        AZ_COMPONENT(XRExampleComponent, "{A7D9A921-1FF9-4078-92BD-169E258456E7}", AZ::Component);
+        AZ_COMPONENT(XRExampleComponent, "{A7D9A921-1FF9-4078-92BD-169E258456E7}");
         AZ_DISABLE_COPY(XRExampleComponent);
 
         static void Reflect(AZ::ReflectContext* context);
@@ -44,16 +44,15 @@ namespace AtomSampleViewer
 
     protected:
         // 1 cube for view + 2 cubes for the controller
-        static const uint32_t s_numberOfCubes = 3; 
- 
-        static const uint32_t s_geometryVertexCount = 24;
-        static const uint32_t s_geometryIndexCount = 36;
+        static const uint32_t NumberOfCubes = 3; 
+        static const uint32_t GeometryVertexCount = 24;
+        static const uint32_t GeometryIndexCount = 36;
 
         struct SingleCubeBufferData
         {
-            AZStd::array<VertexPosition, s_geometryVertexCount> m_positions;
-            AZStd::array<VertexColor, s_geometryVertexCount> m_colors;
-            AZStd::array<uint16_t, s_geometryIndexCount> m_indices;
+            AZStd::array<VertexPosition, GeometryVertexCount> m_positions;
+            AZStd::array<VertexColor, GeometryVertexCount> m_colors;
+            AZStd::array<uint16_t, GeometryIndexCount> m_indices;
         };
 
         // AZ::Component
@@ -69,7 +68,7 @@ namespace AtomSampleViewer
         //! Create IA data
         void CreateCubeInputAssemblyBuffer();
         //! Create Cube data
-        SingleCubeBufferData CreateSingleCubeBufferData(const AZ::Vector4 color);
+        SingleCubeBufferData CreateSingleCubeBufferData();
         //! Create PSO data
         void CreateCubePipeline();
         //! Create the relevant Scope
@@ -91,11 +90,12 @@ namespace AtomSampleViewer
         AZStd::array<AZ::RHI::StreamBufferView, 2> m_streamBufferViews;
         AZ::RHI::DrawItem m_drawItem;
         float m_time = 0.0f;
-        AZStd::array<AZ::Data::Instance<AZ::RPI::ShaderResourceGroup>, s_numberOfCubes> m_shaderResourceGroups;
-        AZStd::array<AZ::Matrix4x4, s_numberOfCubes> m_modelMatrices;
+        AZStd::array<AZ::Data::Instance<AZ::RPI::ShaderResourceGroup>, NumberOfCubes> m_shaderResourceGroups;
+        AZStd::array<AZ::Matrix4x4, NumberOfCubes> m_modelMatrices;
         AZ::Matrix4x4 m_viewProjMatrix;
 
         AZ::RHI::ShaderInputConstantIndex m_shaderIndexWorldMat;
         AZ::RHI::ShaderInputConstantIndex m_shaderIndexViewProj;  
+        AZ::RHI::AttachmentId m_depthStencilID;
     };
 } // namespace AtomSampleViewer

--- a/Gem/Code/Source/RHI/XRExampleComponent.h
+++ b/Gem/Code/Source/RHI/XRExampleComponent.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Component/Component.h>
+
+#include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
+
+#include <Atom/RHI/FrameScheduler.h>
+#include <Atom/RHI/DrawItem.h>
+#include <Atom/RHI/Device.h>
+#include <Atom/RHI/Factory.h>
+#include <Atom/RHI/PipelineState.h>
+#include <Atom/RHI/BufferPool.h>
+
+#include <AzCore/Math/Matrix4x4.h>
+
+#include <RHI/BasicRHIComponent.h>
+#include <AzCore/Component/TickBus.h>
+
+namespace AtomSampleViewer
+{
+    //! The purpose of this sample is to establish a simple XR sample utilizing a simple VR pipeline
+    //! It will render a mesh per controller plus one for the front view. It will prove out all the 
+    //! code related related to openxr device, instance, swapchain, session, input, space.       
+    class XRExampleComponent final
+        : public BasicRHIComponent
+        , public AZ::TickBus::Handler
+    {
+    public:
+        AZ_COMPONENT(XRExampleComponent, "{A7D9A921-1FF9-4078-92BD-169E258456E7}", AZ::Component);
+        AZ_DISABLE_COPY(XRExampleComponent);
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        XRExampleComponent();
+        ~XRExampleComponent() override = default;
+
+    protected:
+        // 1 cube for view + 2 cubes for the controller
+        static const uint32_t s_numberOfCubes = 3; 
+ 
+        static const uint32_t s_geometryVertexCount = 24;
+        static const uint32_t s_geometryIndexCount = 36;
+
+        struct SingleCubeBufferData
+        {
+            AZStd::array<VertexPosition, s_geometryVertexCount> m_positions;
+            AZStd::array<VertexColor, s_geometryVertexCount> m_colors;
+            AZStd::array<uint16_t, s_geometryIndexCount> m_indices;
+        };
+
+        // AZ::Component
+        void Activate() override;
+        void Deactivate() override;
+
+        // RHISystemNotificationBus::Handler
+        void OnFramePrepare(AZ::RHI::FrameGraphBuilder& frameGraphBuilder) override;
+
+        // TickBus::Handler
+        void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
+
+        //! Create IA data
+        void CreateCubeInputAssemblyBuffer();
+        //! Create Cube data
+        SingleCubeBufferData CreateSingleCubeBufferData(const AZ::Vector4 color);
+        //! Create PSO data
+        void CreateCubePipeline();
+        //! Create the relevant Scope
+        void CreateScope();
+
+        AZ::RHI::Ptr<AZ::RHI::BufferPool> m_bufferPool;
+        AZ::RHI::IndexBufferView m_indexBufferView;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_inputAssemblyBuffer;
+        AZ::RHI::InputStreamLayout m_streamLayoutDescriptor;
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_pipelineState;
+
+        struct BufferData
+        {
+            AZStd::array<VertexPosition, 3> m_positions;
+            AZStd::array<VertexColor, 3> m_colors;
+            AZStd::array<uint16_t, 3> m_indices;
+        };
+
+        AZStd::array<AZ::RHI::StreamBufferView, 2> m_streamBufferViews;
+        AZ::RHI::DrawItem m_drawItem;
+        float m_time = 0.0f;
+        AZStd::array<AZ::Data::Instance<AZ::RPI::ShaderResourceGroup>, s_numberOfCubes> m_shaderResourceGroups;
+        AZStd::array<AZ::Matrix4x4, s_numberOfCubes> m_modelMatrices;
+        AZ::Matrix4x4 m_viewProjMatrix;
+
+        AZ::RHI::ShaderInputConstantIndex m_shaderIndexWorldMat;
+        AZ::RHI::ShaderInputConstantIndex m_shaderIndexViewProj;  
+    };
+} // namespace AtomSampleViewer

--- a/Gem/Code/Source/SampleComponentManager.cpp
+++ b/Gem/Code/Source/SampleComponentManager.cpp
@@ -60,6 +60,7 @@
 #include <RHI/TextureExampleComponent.h>
 #include <RHI/TextureMapExampleComponent.h>
 #include <RHI/TriangleExampleComponent.h>
+#include <RHI/XRExampleComponent.h>
 #include <RHI/TrianglesConstantBufferExampleComponent.h>
 #include <RHI/BindlessPrototypeExampleComponent.h>
 #include <RHI/RayTracingExampleComponent.h>
@@ -275,6 +276,7 @@ namespace AtomSampleViewer
             NewRHISample<TextureMapExampleComponent>("TextureMap"),
             NewRHISample<TriangleExampleComponent>("Triangle"),
             NewRHISample<TrianglesConstantBufferExampleComponent>("TrianglesConstantBuffer"),
+            NewRHISample<XRExampleComponent>("OpenXr"),
             NewRHISample<MatrixAlignmentTestExampleComponent>("MatrixAlignmentTest"),
             NewRPISample<AssetLoadTestComponent>("AssetLoadTest"),
             NewRPISample<AuxGeomExampleComponent>("AuxGeom"),
@@ -529,6 +531,20 @@ namespace AtomSampleViewer
 
     void SampleComponentManager::OnTick(float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)
     {
+        AZ::RPI::RPISystemInterface* rpiSystem = AZ::RPI::RPISystemInterface::Get();
+        if (rpiSystem->GetXRSystem())
+        {
+            //Only enable XR pipelines if the XR drivers indicate we have accurate pose information from the device
+            if (rpiSystem->GetXRSystem()->ShouldRender())
+            {
+                EnableXrPipelines();
+            }
+            else
+            {
+                DisableXrPipelines();
+            }
+        }
+
         m_imGuiFrameTimer.PushValue(deltaTime * 1000.0f);
 
         bool screenshotRequest = false;
@@ -1329,22 +1345,21 @@ namespace AtomSampleViewer
     {
         m_exampleEntity->Deactivate();
 
-        // Pointer to the m_activeSample must be nullified before m_activeSample is destroyed.
-        if (m_rhiSamplePass)
+        // Pointer to all the passes within m_rhiSamplePasses must be nullified before all the samples within m_activeSamples are destroyed.
+        SetRHISamplePass(nullptr);
+
+        for (AZ::Component* activeComponent : m_activeSamples)
         {
-            m_rhiSamplePass->SetRHISample(nullptr);
+            if (activeComponent != nullptr)
+            {
+                // Disable the camera controller just in case the active sample enabled it and didn't disable in Deactivate().
+                AZ::Debug::CameraControllerRequestBus::Event(m_cameraEntity->GetId(), &AZ::Debug::CameraControllerRequestBus::Events::Disable);
+
+                m_exampleEntity->RemoveComponent(activeComponent);
+                delete activeComponent;
+            }
         }
-
-        if (m_activeSample != nullptr)
-        {
-            // Disable the camera controller just in case the active sample enabled it and didn't disable in Deactivate().
-            AZ::Debug::CameraControllerRequestBus::Event(m_cameraEntity->GetId(), &AZ::Debug::CameraControllerRequestBus::Events::Disable);
-
-            m_exampleEntity->RemoveComponent(m_activeSample);
-            delete m_activeSample;
-        }
-
-        m_activeSample = nullptr;
+        m_activeSamples.clear();
 
         // Force a reset of the shader variant finder to get more consistent testing of samples every time they are run, rather
         // than the first time for each sample being "special".
@@ -1360,7 +1375,7 @@ namespace AtomSampleViewer
 
         // Reset to RHI sample pipeline
         SwitchSceneForRHISample();
-        m_rhiSamplePass->SetRHISample(nullptr);
+        SetRHISamplePass(nullptr);
     }
 
     void SampleComponentManager::CreateDefaultCamera()
@@ -1482,23 +1497,28 @@ namespace AtomSampleViewer
         }
 
         SampleComponentConfig config(m_windowContext, m_cameraEntity->GetId(), m_entityContextId);
-        m_activeSample = m_exampleEntity->CreateComponent(sampleEntry.m_sampleUuid);
-        m_activeSample->SetConfiguration(config);
 
-        // special setup for RHI samples
-        if (sampleEntry.m_pipelineType == SamplePipelineType::RHI)
+        for (AZ::RPI::Ptr<RHISamplePass> samplePass : m_rhiSamplePasses)
         {
-            BasicRHIComponent* rhiSampleComponent = static_cast<BasicRHIComponent*>(m_activeSample);
-            if (rhiSampleComponent->IsSupportedRHISamplePipeline())
+            AZ::Component* newComponent = m_exampleEntity->CreateComponent(sampleEntry.m_sampleUuid);
+            newComponent->SetConfiguration(config);
+            
+            // special setup for RHI samples
+            if (sampleEntry.m_pipelineType == SamplePipelineType::RHI)
             {
-                m_rhiSamplePass->SetRHISample(rhiSampleComponent);
+                BasicRHIComponent* rhiSampleComponent = static_cast<BasicRHIComponent*>(newComponent);
+                rhiSampleComponent->SetViewIndex(samplePass->GetViewIndex());
+                if (rhiSampleComponent->IsSupportedRHISamplePipeline())
+                {
+                    samplePass->SetRHISample(rhiSampleComponent);
+                }
+                else
+                {
+                    samplePass->SetRHISample(nullptr);
+                }
             }
-            else
-            {
-                m_rhiSamplePass->SetRHISample(nullptr);
-            }
+            m_activeSamples.push_back(newComponent);
         }
-
         m_exampleEntity->Activate();
 
         // Even though this is done in CameraReset(), the example component wasn't activated at the time so we have to send this event again.
@@ -1527,21 +1547,60 @@ namespace AtomSampleViewer
         m_rhiScene->Activate();
 
         RPI::RenderPipelineDescriptor pipelineDesc;
+
         pipelineDesc.m_name = "RHISamplePipeline";
         pipelineDesc.m_rootPassTemplate = "RHISamplePipelineTemplate";
         // Add view to pipeline since there are few RHI samples are using ViewSrg
         pipelineDesc.m_mainViewTagName = "MainCamera";
 
-        RPI::RenderPipelinePtr renderPipeline = RPI::RenderPipeline::CreateRenderPipelineForWindow(pipelineDesc, *m_windowContext.get());
-        m_rhiScene->AddRenderPipeline(renderPipeline);
-        renderPipeline->SetDefaultViewFromEntity(m_cameraEntity->GetId());
-
-        RPI::RPISystemInterface::Get()->RegisterScene(m_rhiScene);
+        m_renderPipeline = RPI::RenderPipeline::CreateRenderPipelineForWindow(pipelineDesc, *m_windowContext.get());
+        m_rhiScene->AddRenderPipeline(m_renderPipeline);
+        m_renderPipeline->SetDefaultViewFromEntity(m_cameraEntity->GetId());
+        
 
         // Get RHISamplePass
-        AZ::RPI::PassFilter passFilter = AZ::RPI::PassFilter::CreateWithPassName(AZ::Name("RHISamplePass"), renderPipeline.get());
-        m_rhiSamplePass = azrtti_cast<RHISamplePass*>(AZ::RPI::PassSystemInterface::Get()->FindFirstPass(passFilter));
+        AZ::RPI::PassFilter passFilter = AZ::RPI::PassFilter::CreateWithPassName(AZ::Name("RHISamplePass"), m_renderPipeline.get());
+        m_rhiSamplePasses.push_back(azrtti_cast<RHISamplePass*>(AZ::RPI::PassSystemInterface::Get()->FindFirstPass(passFilter)));
 
+        AZ::RPI::RPISystemInterface* rpiSystem = AZ::RPI::RPISystemInterface::Get();
+        if (rpiSystem->GetXRSystem())
+        {
+            // Build the pipeline for left eye
+            pipelineDesc.m_name = "RHISamplePipelineXRLeft";
+            pipelineDesc.m_rootPassTemplate = "RHISamplePipelineXRLeftTemplate";
+            RPI::RenderPipelinePtr renderPipelineLeft = RPI::RenderPipeline::CreateRenderPipelineForWindow(pipelineDesc, *m_windowContext.get(), AZ::RPI::WindowContext::SwapChainMode::XrLeft);
+            // Build the pipeline for right eye
+            pipelineDesc.m_name = "RHISamplePipelineXRRight";
+            pipelineDesc.m_rootPassTemplate = "RHISamplePipelineXRRightTemplate";
+            RPI::RenderPipelinePtr renderPipelineRight = RPI::RenderPipeline::CreateRenderPipelineForWindow(pipelineDesc, *m_windowContext.get(), AZ::RPI::WindowContext::SwapChainMode::XrRight);
+
+            //Add both the pipelines to the scene
+            m_rhiScene->AddRenderPipeline(renderPipelineLeft);
+            m_rhiScene->AddRenderPipeline(renderPipelineRight);
+            renderPipelineLeft->SetDefaultViewFromEntity(m_cameraEntity->GetId());
+            renderPipelineRight->SetDefaultViewFromEntity(m_cameraEntity->GetId());
+            
+            // Set the correct view index for the RHI sample passes
+            AZ::RPI::PassFilter rhiSamplePassFilterLeft = AZ::RPI::PassFilter::CreateWithPassName(AZ::Name("RHISamplePass"), renderPipelineLeft.get());
+            AZ::RPI::Ptr<RHISamplePass> rhiSamplePassLeft = azrtti_cast<RHISamplePass*>(AZ::RPI::PassSystemInterface::Get()->FindFirstPass(rhiSamplePassFilterLeft));
+            rhiSamplePassLeft->SetViewIndex(0);
+            m_rhiSamplePasses.push_back(rhiSamplePassLeft);
+
+            AZ::RPI::PassFilter rhiSamplePassFilterRight = AZ::RPI::PassFilter::CreateWithPassName(AZ::Name("RHISamplePass"), renderPipelineRight.get());
+            AZ::RPI::Ptr<RHISamplePass> rhiSamplePassRight = azrtti_cast<RHISamplePass*>(AZ::RPI::PassSystemInterface::Get()->FindFirstPass(rhiSamplePassFilterRight));
+            rhiSamplePassRight->SetViewIndex(1);
+            m_rhiSamplePasses.push_back(rhiSamplePassRight);
+
+            //Cache the pipelines in case we want to enable/disable them
+            m_xrPipelines.push_back(renderPipelineLeft);
+            m_xrPipelines.push_back(renderPipelineRight);
+
+            //Disable XR pipelines by default
+            DisableXrPipelines();
+        }
+
+        // REgister the RHi scene
+        RPI::RPISystemInterface::Get()->RegisterScene(m_rhiScene);  
         // Setup imGui since a new render pipeline with imgui pass was created
         SetupImGuiContext();
     }
@@ -1550,7 +1609,9 @@ namespace AtomSampleViewer
     {
         if (m_rhiScene)
         {
-            m_rhiSamplePass = nullptr;
+            m_rhiSamplePasses.clear();
+            m_xrPipelines.clear();
+            m_renderPipeline = nullptr;
             RPI::RPISystemInterface::Get()->UnregisterScene(m_rhiScene);
             m_rhiScene = nullptr;
         }
@@ -1660,6 +1721,30 @@ namespace AtomSampleViewer
             {
                 ActivateInternal();
             });
+    }
+    
+    void SampleComponentManager::SetRHISamplePass(BasicRHIComponent* sampleComponent)
+    {
+        for (AZ::RPI::Ptr<RHISamplePass> samplePass : m_rhiSamplePasses)
+        {
+            samplePass->SetRHISample(sampleComponent);
+        }
+    }
+
+    void SampleComponentManager::DisableXrPipelines()
+    {
+        for (RPI::RenderPipelinePtr xrPipeline : m_xrPipelines)
+        {
+            xrPipeline->RemoveFromRenderTick();
+        }
+    }
+
+    void SampleComponentManager::EnableXrPipelines()
+    {
+        for (RPI::RenderPipelinePtr xrPipeline : m_xrPipelines)
+        {
+            xrPipeline->AddToRenderTick();
+        }
     }
 
 } // namespace AtomSampleViewer

--- a/Gem/Code/Source/SampleComponentManager.h
+++ b/Gem/Code/Source/SampleComponentManager.h
@@ -192,7 +192,7 @@ namespace AtomSampleViewer
         // Entity to hold only example component. It doesn't need an entity context.
         AZ::Entity* m_exampleEntity = nullptr;
 
-        AZStd::vector<AZ::Component*> m_activeSamples;;
+        AZStd::vector<AZ::Component*> m_activeSamples;
 
         AZ::Entity* m_cameraEntity = nullptr;
 

--- a/Gem/Code/Source/SampleComponentManager.h
+++ b/Gem/Code/Source/SampleComponentManager.h
@@ -145,6 +145,9 @@ namespace AtomSampleViewer
         void SampleChange();
         void CameraReset();
         void ShutdownActiveSample();
+        void SetRHISamplePass(BasicRHIComponent* sampleComponent);
+        void DisableXrPipelines();
+        void EnableXrPipelines();
 
         // SampleComponentManagerRequestBus overrides...
         void Reset() override;
@@ -189,7 +192,7 @@ namespace AtomSampleViewer
         // Entity to hold only example component. It doesn't need an entity context.
         AZ::Entity* m_exampleEntity = nullptr;
 
-        AZ::Component* m_activeSample = nullptr;
+        AZStd::vector<AZ::Component*> m_activeSamples;;
 
         AZ::Entity* m_cameraEntity = nullptr;
 
@@ -258,12 +261,16 @@ namespace AtomSampleViewer
 
         // Scene and some variables for RHI samples
         AZ::RPI::ScenePtr m_rhiScene;
-        AZ::RPI::Ptr<RHISamplePass> m_rhiSamplePass = nullptr;
+        AZStd::vector<AZ::RPI::Ptr<RHISamplePass>> m_rhiSamplePasses;
 
         // Scene and some variables for RPI samples
         AZ::RPI::ScenePtr m_rpiScene;
 
         // number of MSAA samples, initialized in Activate() and can vary by platform
         int m_numMSAASamples = 0;
+
+        // Cache PC and XR pipelines
+        AZ::RPI::RenderPipelinePtr m_renderPipeline = nullptr;
+        AZStd::vector<AZ::RPI::RenderPipelinePtr> m_xrPipelines;
     };
 } // namespace AtomSampleViewer

--- a/Gem/Code/atomsampleviewergem_private_files.cmake
+++ b/Gem/Code/atomsampleviewergem_private_files.cmake
@@ -83,6 +83,8 @@ set(FILES
     Source/RHI/RayTracingExampleComponent.h
     Source/RHI/MatrixAlignmentTestExampleComponent.cpp
     Source/RHI/MatrixAlignmentTestExampleComponent.h
+    Source/RHI/XRExampleComponent.cpp
+    Source/RHI/XRExampleComponent.h
     Source/Performance/HighInstanceExampleComponent.cpp
     Source/Performance/HighInstanceExampleComponent.h
     Source/Performance/100KDrawable_SingleView_ExampleComponent.cpp

--- a/Gem/Code/enabled_gems.cmake
+++ b/Gem/Code/enabled_gems.cmake
@@ -23,6 +23,6 @@ set(ENABLED_GEMS
     MaterialEditor
     UiBasics
     StreamerProfiler
-    XR #added via call to enable-gem
-    OpenXRVk #added via call to enable-gem
+    XR
+    OpenXRVk
 )

--- a/Gem/Code/enabled_gems.cmake
+++ b/Gem/Code/enabled_gems.cmake
@@ -23,4 +23,6 @@ set(ENABLED_GEMS
     MaterialEditor
     UiBasics
     StreamerProfiler
+    XR #added via call to enable-gem
+    OpenXRVk #added via call to enable-gem
 )

--- a/Passes/ASV/PassTemplates.azasset
+++ b/Passes/ASV/PassTemplates.azasset
@@ -61,6 +61,14 @@
                 "Path": "Passes/RHISamplePipeline.pass"
             },
             {
+                "Name": "RHISamplePipelineXRLeftTemplate",
+                "Path": "Passes/RHISamplePipelineXRLeft.pass"
+            },
+            {
+                "Name": "RHISamplePipelineXRRightTemplate",
+                "Path": "Passes/RHISamplePipelineXRRight.pass"
+            },
+            {
                 "Name": "SsaoPipeline",
                 "Path": "Passes/SsaoPipeline.pass"
             },

--- a/Passes/RHISamplePipelineXRLeft.pass
+++ b/Passes/RHISamplePipelineXRLeft.pass
@@ -1,0 +1,74 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "PassAsset",
+    "ClassData": {
+        "PassTemplate": {
+            "Name": "RHISamplePipelineXRLeftTemplate",
+            "PassClass": "ParentPass",
+            "Slots": [
+                {
+                    "Name": "SwapChainOutput",
+                    "SlotType": "InputOutput"
+                }
+            ],
+            "PassData": {
+                "$type": "PassData",
+                "PipelineGlobalConnections": [
+                    {
+                        "GlobalName": "SwapChainOutput",
+                        "Slot": "SwapChainOutput"
+                    }
+                ]
+            },
+            "PassRequests": [
+                {
+                    "Name": "RHISamplePass",
+                    "TemplateName": "RHISamplePassTemplate",
+                    "Enabled": true,
+                    "ExecuteAfter": [
+                        "BeginXRPass"
+                    ]
+                },
+                {
+                    "Name": "ImGuiPass",
+                    "TemplateName": "ImGuiPassTemplate",
+                    "Enabled": true,
+                    "Connections": [
+                        {
+                            "LocalSlot": "InputOutput",
+                            "AttachmentRef": {
+                                "Pass": "RHISamplePass",
+                                "Attachment": "Output"
+                            }
+                        }
+                    ],
+                    "PassData": {
+                        "$type": "ImGuiPassData",
+                        "IsDefaultImGui": true
+                    }
+                },
+                {
+                    "Name": "CopyToSwapChain",
+                    "TemplateName": "FullscreenCopyTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "Input",
+                            "AttachmentRef": {
+                                "Pass": "ImGuiPass",
+                                "Attachment": "InputOutput"
+                            }
+                        },
+                        {
+                            "LocalSlot": "Output",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "SwapChainOutput"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/Passes/RHISamplePipelineXRRight.pass
+++ b/Passes/RHISamplePipelineXRRight.pass
@@ -1,0 +1,74 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "PassAsset",
+    "ClassData": {
+        "PassTemplate": {
+            "Name": "RHISamplePipelineXRRightTemplate",
+            "PassClass": "ParentPass",
+            "Slots": [
+                {
+                    "Name": "SwapChainOutput",
+                    "SlotType": "InputOutput"
+                }
+            ],
+            "PassData": {
+                "$type": "PassData",
+                "PipelineGlobalConnections": [
+                    {
+                        "GlobalName": "SwapChainOutput",
+                        "Slot": "SwapChainOutput"
+                    }
+                ]
+            },
+            "PassRequests": [
+                {
+                    "Name": "RHISamplePass",
+                    "TemplateName": "RHISamplePassTemplate",
+                    "Enabled": true,
+                    "ExecuteAfter": [
+                        "BeginXRPass"
+                    ]
+                },
+                {
+                    "Name": "ImGuiPass",
+                    "TemplateName": "ImGuiPassTemplate",
+                    "Enabled": true,
+                    "Connections": [
+                        {
+                            "LocalSlot": "InputOutput",
+                            "AttachmentRef": {
+                                "Pass": "RHISamplePass",
+                                "Attachment": "Output"
+                            }
+                        }
+                    ],
+                    "PassData": {
+                        "$type": "ImGuiPassData",
+                        "IsDefaultImGui": true
+                    }
+                },
+                {
+                    "Name": "CopyToSwapChain",
+                    "TemplateName": "FullscreenCopyTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "Input",
+                            "AttachmentRef": {
+                                "Pass": "ImGuiPass",
+                                "Attachment": "InputOutput"
+                            }
+                        },
+                        {
+                            "LocalSlot": "Output",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "SwapChainOutput"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/Shaders/RHI/OpenXrSample.azsl
+++ b/Shaders/RHI/OpenXrSample.azsl
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/Features/SrgSemantics.azsli>
+
+ShaderResourceGroup OpenXrSrg : SRG_PerObject
+{
+    row_major float4x4 m_worldMatrix;
+    row_major float4x4 m_viewProjMatrix;
+}
+
+struct VSInput
+{
+    float3 m_position : POSITION;
+    float4 m_color : COLOR0;
+};
+
+struct VSOutput
+{
+    float4 m_position : SV_Position;
+    float4 m_color : COLOR0;
+};
+
+VSOutput MainVS(VSInput vsInput)
+{
+    VSOutput OUT;
+    
+    OUT.m_position = mul(OpenXrSrg::m_worldMatrix, float4(vsInput.m_position, 1.0));
+    OUT.m_position = mul(OpenXrSrg::m_viewProjMatrix, OUT.m_position);
+    OUT.m_color = vsInput.m_color;
+    return OUT;
+}
+
+struct PSOutput
+{
+    float4 m_color : SV_Target0;
+};
+
+PSOutput MainPS(VSOutput vsOutput)
+{
+    PSOutput OUT;
+    OUT.m_color = vsOutput.m_color;
+    return OUT;
+}

--- a/Shaders/RHI/OpenXrSample.shader
+++ b/Shaders/RHI/OpenXrSample.shader
@@ -1,0 +1,23 @@
+{
+    "Source" : "OpenXrSample.azsl",
+
+    "DepthStencilState" : { 
+        "Depth" : { "Enable" : false, "CompareFunc" : "Less" }
+    },
+    "DrawList" : "forward",
+
+    "ProgramSettings":
+    {
+      "EntryPoints":
+      [
+        {
+          "name": "MainVS",
+          "type": "Vertex"
+        },
+        {
+          "name": "MainPS",
+          "type": "Fragment"
+        }
+      ]
+    }
+}

--- a/project.json
+++ b/project.json
@@ -13,5 +13,9 @@
     ],
     "icon_path": "preview.png",
     "engine": "o3de",
-    "external_subdirectories": []
+    "external_subdirectories": [],
+    "gem_names": [
+        "XR", // added via call to enable-gem
+        "OpenXRVk" // added via call to enable-gem
+    ]
 }

--- a/project.json
+++ b/project.json
@@ -15,7 +15,7 @@
     "engine": "o3de",
     "external_subdirectories": [],
     "gem_names": [
-        "XR", // added via call to enable-gem
-        "OpenXRVk" // added via call to enable-gem
+        "XR",
+        "OpenXRVk"
     ]
 }


### PR DESCRIPTION
- Create a new RHI sample for OpenXr
- Update ASV to support a simple VR pipeline that creates two pipelines (one for the left eye and one for the right eye). We end up running 3 pipelines for this sample as there is an extra one for PC. This allows for debugging capability when headset comes off.
- Add extracting view data per view and using it to set the appropriate view projection matrix per eye
- The sample pass renders 3 cubes -> One cube per controller and another to show the view in front of the device
- Update controller position, orientation and scale

XR/Openxr side PR - https://github.com/aws-lumberyard/gallifrey/pull/6
Core engine PR - https://github.com/o3de/o3de/pull/10170

![image](https://user-images.githubusercontent.com/47460854/174192326-cff85a45-f01c-447b-b794-b4fb93339ad0.png)

Signed-off-by: moudgils <47460854+moudgils@users.noreply.github.com>