### PR TITLE
Added CVAR to enable default render pipeline when there is an XR System present.

### DIFF
--- a/Gem/Code/Source/SampleComponentManager.cpp
+++ b/Gem/Code/Source/SampleComponentManager.cpp
@@ -118,6 +118,7 @@
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzCore/std/algorithm.h>
+#include <AzCore/Console/IConsole.h>
 
 #include <AzFramework/API/ApplicationAPI.h>
 #include <AzFramework/Components/ConsoleBus.h>
@@ -143,6 +144,9 @@ namespace Platform
 
 namespace AtomSampleViewer
 {
+    AZ_CVAR(bool, r_EnableDefaultRenderPipelineOnXR, false, nullptr, AZ::ConsoleFunctorFlags::Null,
+        "When an XR system is present this will enable the regular render pipeline on host PC as well (false by default).");
+
     namespace
     {
         constexpr const char* PassTreeToolName = "PassTree";
@@ -1606,6 +1610,12 @@ namespace AtomSampleViewer
             m_xrPipelines.push_back(renderPipelineLeft);
             m_xrPipelines.push_back(renderPipelineRight);
 
+            // Disable default pipeline
+            if (!r_EnableDefaultRenderPipelineOnXR)
+            {
+                m_renderPipeline->RemoveFromRenderTick();
+            }
+
             //Disable XR pipelines by default
             DisableXrPipelines();
         }
@@ -1670,10 +1680,10 @@ namespace AtomSampleViewer
         const char* supervariantName = isNonMsaaPipeline ? AZ::RPI::NoMsaaSupervariantName : "";
         AZ::RPI::ShaderSystemInterface::Get()->SetSupervariantName(AZ::Name(supervariantName));
 
-        RPI::RenderPipelinePtr renderPipeline = RPI::RenderPipeline::CreateRenderPipelineForWindow(pipelineDesc, *m_windowContext.get());
-        m_rpiScene->AddRenderPipeline(renderPipeline);
+        m_renderPipeline = RPI::RenderPipeline::CreateRenderPipelineForWindow(pipelineDesc, *m_windowContext.get());
+        m_rpiScene->AddRenderPipeline(m_renderPipeline);
 
-        renderPipeline->SetDefaultViewFromEntity(m_cameraEntity->GetId());
+        m_renderPipeline->SetDefaultViewFromEntity(m_cameraEntity->GetId());
 
         AZ::RPI::RPISystemInterface* rpiSystem = AZ::RPI::RPISystemInterface::Get();
         if (rpiSystem->GetXRSystem())
@@ -1698,6 +1708,12 @@ namespace AtomSampleViewer
             //Cache the pipelines in case we want to enable/disable them
             m_xrPipelines.push_back(renderPipelineLeft);
             m_xrPipelines.push_back(renderPipelineRight);
+
+            // Disable default pipeline
+            if (!r_EnableDefaultRenderPipelineOnXR)
+            {
+                m_renderPipeline->RemoveFromRenderTick();
+            }
 
             // Disable XR pipelines by default
             DisableXrPipelines();


### PR DESCRIPTION
Signed-off-by: moraaar <moraaar@amazon.com>

Fixes https://github.com/o3de/o3de/issues/11254