### PR TITLE
Prepare ASV to handle optional OpenXR Gems

### DIFF
--- a/Gem/CMakeLists.txt
+++ b/Gem/CMakeLists.txt
@@ -6,6 +6,4 @@
 #
 #
 
-set(ASV_OPENXR_SAMPLE_ENABLED FALSE CACHE BOOL "Enable the OpenXR Gems and samples in Atom Sample Viewer")
-
 add_subdirectory(Code)

--- a/Gem/Code/Source/Platform/Windows/additional_windows_runtime_library.cmake
+++ b/Gem/Code/Source/Platform/Windows/additional_windows_runtime_library.cmake
@@ -5,8 +5,3 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #
-
-set(LY_RUNTIME_DEPENDENCIES
-    Gem::XR
-    Gem::OpenXRVk
-)

--- a/Gem/Code/Source/RHI/XRExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/XRExampleComponent.cpp
@@ -35,6 +35,11 @@ namespace AtomSampleViewer
 
     void XRExampleComponent::Activate()
     {
+        if (!AZ::RPI::RPISystemInterface::Get()->GetXRSystem())
+        {
+            return;
+        }
+
         m_depthStencilID = AZ::RHI::AttachmentId{ AZStd::string::format("DepthStencilID_%llu", GetId()) };
         CreateCubeInputAssemblyBuffer();
         CreateCubePipeline();
@@ -385,6 +390,11 @@ namespace AtomSampleViewer
 
     void XRExampleComponent::Deactivate()
     {
+        if (!AZ::RPI::RPISystemInterface::Get()->GetXRSystem())
+        {
+            return;
+        }
+
         m_inputAssemblyBuffer = nullptr;
         m_bufferPool = nullptr;
         m_pipelineState = nullptr;

--- a/Gem/Code/Source/XRRPIExampleComponent.cpp
+++ b/Gem/Code/Source/XRRPIExampleComponent.cpp
@@ -20,6 +20,8 @@
 
 #include <SSRExampleComponent_Traits_Platform.h>
 
+#include "Atom/RPI.Public/RPISystem.h"
+
 namespace AtomSampleViewer
 {
     static const float ControllerOffsetScale = 2.0f;
@@ -37,13 +39,18 @@ namespace AtomSampleViewer
 
     void XRRPIExampleComponent::Activate()
     {
+        if (m_xrSystem = AZ::RPI::RPISystemInterface::Get()->GetXRSystem();
+            m_xrSystem == nullptr)
+        {
+            return;
+        }
+
         AZ::TickBus::Handler::BusConnect();
 
         // setup the camera
         Camera::CameraRequestBus::EventResult(m_originalFarClipDistance, GetCameraEntityId(), &Camera::CameraRequestBus::Events::GetFarClipDistance);
         Camera::CameraRequestBus::Event(GetCameraEntityId(), &Camera::CameraRequestBus::Events::SetFarClipDistance, 180.f);
 
-        m_xrSystem = AZ::RPI::RPISystemInterface::Get()->GetXRSystem();
         m_numXrViews = m_xrSystem->GetNumViews();
 
         // create scene
@@ -55,6 +62,11 @@ namespace AtomSampleViewer
 
     void XRRPIExampleComponent::Deactivate()
     {
+        if (!m_xrSystem)
+        {
+            return;
+        }
+
         ShutdownLightingPresets();
 
         GetMeshFeatureProcessor()->ReleaseMesh(m_statueMeshHandle);
@@ -113,7 +125,7 @@ namespace AtomSampleViewer
             AZ::Data::Asset<AZ::RPI::MaterialAsset> materialAsset = AZ::RPI::AssetUtils::GetAssetByProductPath<AZ::RPI::MaterialAsset>("Materials/XR/XR_Hand_Controller_ControlerMAT.azmaterial", AZ::RPI::AssetUtils::TraceLevel::Assert);
             AZ::Data::Asset<AZ::RPI::ModelAsset> modelAsset = AZ::RPI::AssetUtils::GetAssetByProductPath<AZ::RPI::ModelAsset>("objects/left_hand_controller.azmodel", AZ::RPI::AssetUtils::TraceLevel::Assert);
             AZ::Transform transform = AZ::Transform::CreateIdentity();
-            
+
             m_leftControllerMeshHandle = GetMeshFeatureProcessor()->AcquireMesh(AZ::Render::MeshHandleDescriptor{ modelAsset }, AZ::RPI::Material::FindOrCreate(materialAsset));
             m_rightControllerMeshHandle = GetMeshFeatureProcessor()->AcquireMesh(AZ::Render::MeshHandleDescriptor{ modelAsset }, AZ::RPI::Material::FindOrCreate(materialAsset));
             GetMeshFeatureProcessor()->SetTransform(m_leftControllerMeshHandle, transform);
@@ -182,7 +194,7 @@ namespace AtomSampleViewer
                 resultCode = m_xrSystem->GetControllerPose(i, controllerPose);
 
                 if(resultCode == AZ::RHI::ResultCode::Success && !controllerPose.m_orientation.IsZero())
-                { 
+                {
                     AZ::Vector3 camPosition;
                     AZ::TransformBus::EventResult(camPosition, GetCameraEntityId(), &AZ::TransformBus::Events::GetWorldTranslation);
                     AZ::Vector3 controllerPositionOffset = controllerPose.m_position * ControllerOffsetScale;
@@ -197,16 +209,16 @@ namespace AtomSampleViewer
                     //Apply a Rotation of 90 deg around X axis in order to orient the model to face away from you as default pose
                     AZ::Transform controllerTransform = AZ::Transform::CreateFromQuaternionAndTranslation(
                                 controllerOrientation * AZ::Quaternion::CreateRotationX(-AZ::Constants::Pi / 2), AZ::Vector3(newControllerPos.GetX(), newControllerPos.GetY(),newControllerPos.GetZ()));
-                
+
                     AZ::Render::MeshFeatureProcessorInterface::MeshHandle* controllerMeshhandle = &m_leftControllerMeshHandle;
                     if (i == 1)
                     {
                         controllerMeshhandle = &m_rightControllerMeshHandle;
-                    }   
+                    }
                     GetMeshFeatureProcessor()->SetTransform(*controllerMeshhandle, controllerTransform, AZ::Vector3(m_xrSystem->GetControllerScale(i)));
                 }
             }
-            
+
             //Update Camera movement (left, right forward, back) based on left JoyStick controller
             float m_xJoyStickValue = m_xrSystem->GetXJoyStickState(0);
             float m_yJoyStickValue = m_xrSystem->GetYJoyStickState(0);
@@ -224,7 +236,7 @@ namespace AtomSampleViewer
             // Switch to updating the view using right joystick controller if the Trigger button on the right controller is pressed
             m_rightTriggerButtonPressed = (m_xrSystem->GetTriggerState(1) > 0.1f);
             if (m_rightTriggerButtonPressed)
-            { 
+            {
                 //Update Camera view based on right JoyStick controller
                 float m_xRightJoyStickValue = m_xrSystem->GetXJoyStickState(1);
                 float m_yRightJoyStickValue = m_xrSystem->GetYJoyStickState(1);

--- a/Gem/Code/Source/XRRPIExampleComponent.cpp
+++ b/Gem/Code/Source/XRRPIExampleComponent.cpp
@@ -9,6 +9,7 @@
 #include <XRRPIExampleComponent.h>
 #include <Atom/Component/DebugCamera/NoClipControllerComponent.h>
 #include <Atom/RPI.Public/Scene.h>
+#include <Atom/RPI.Public/RPISystem.h>
 #include <Atom/RPI.Public/RPISystemInterface.h>
 #include <Atom/RPI.Public/Pass/PassFilter.h>
 #include <Atom/RPI.Reflect/Asset/AssetUtils.h>
@@ -20,7 +21,6 @@
 
 #include <SSRExampleComponent_Traits_Platform.h>
 
-#include "Atom/RPI.Public/RPISystem.h"
 
 namespace AtomSampleViewer
 {

--- a/Gem/Code/enabled_gems.cmake
+++ b/Gem/Code/enabled_gems.cmake
@@ -24,6 +24,11 @@ set(ENABLED_GEMS
     UiBasics
     StreamerProfiler
     DiffuseProbeGrid
-    XR
-    OpenXRVk
 )
+
+if(ASV_OPENXR_SAMPLE_ENABLED)
+    list(APPEND ENABLED_GEMS
+        XR
+        OpenXRVk
+    )
+endif()

--- a/Gem/Code/enabled_gems.cmake
+++ b/Gem/Code/enabled_gems.cmake
@@ -24,11 +24,6 @@ set(ENABLED_GEMS
     UiBasics
     StreamerProfiler
     DiffuseProbeGrid
+    XR
+    OpenXRVk
 )
-
-if(ASV_OPENXR_SAMPLE_ENABLED)
-    list(APPEND ENABLED_GEMS
-        XR
-        OpenXRVk
-    )
-endif()

--- a/project.json
+++ b/project.json
@@ -15,7 +15,13 @@
     "engine": "o3de",
     "external_subdirectories": [],
     "gem_names": [
-        "XR",
-        "OpenXRVk"
+        {
+            "name": "OpenXRVk",
+            "optional": true
+        },
+        {
+            "name": "XR",
+            "optional": true
+        }
     ]
 }


### PR DESCRIPTION
This change will mark the XR Gems in ASV as optional, which allows users of the project to configure and run without needing to download and register the XR Gems.

This is in preparation to merge the `openxr` branch to `development` in ASV.

There is a corresponding [PR 13421](https://github.com/o3de/o3de/pull/13421) in `o3de` that this PR depends on which enables this "optional Gem" feature.